### PR TITLE
Add sharp dependency to resolve Astro build failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "astro": "^5.14.1",
         "autoprefixer": "^10.4.21",
         "postcss": "^8.5.6",
+        "sharp": "^0.34.4",
         "tailwindcss": "^3.4.14",
         "vite": "^7.1.9"
       }
@@ -644,7 +645,6 @@
       "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -2697,7 +2697,6 @@
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -5589,7 +5588,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
         "detect-libc": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "astro": "^5.14.1",
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",
+    "sharp": "^0.34.4",
     "tailwindcss": "^3.4.14",
     "vite": "^7.1.9"
   }


### PR DESCRIPTION
## Summary
- add the `sharp` dev dependency so Astro can bundle its image service
- update the lockfile to include the new dependency

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e51f3c590483329bda89d613562c8a