### PR TITLE
Fix bundled script path for client accessibility features

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,5 +1,6 @@
 ---
 import '../styles/tailwind.css';
+import mainScript from '../main.js?url';
 
 interface NavLink {
   href: string;
@@ -137,6 +138,6 @@ const { title, description, mainClass = '', navLinks = defaultNavLinks } = Astro
         </div>
       </div>
     </footer>
-    <script type="module" src="/src/main.js"></script>
+    <script type="module" src={mainScript}></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- use Vite URL import so the main client script is emitted in production builds
- ensure dark mode, text size toggles, and footer year logic load on Netlify

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e52508408c8332adb911aafd4e3002