### PR TITLE
Add esbuild linux binary optional dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,9 @@
         "sharp": "^0.34.4",
         "tailwindcss": "^3.4.14",
         "vite": "^7.1.9"
+      },
+      "optionalDependencies": {
+        "@esbuild/linux-x64": "^0.25.10"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -476,7 +479,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
     "sharp": "^0.34.4",
     "tailwindcss": "^3.4.14",
     "vite": "^7.1.9"
+  },
+  "optionalDependencies": {
+    "@esbuild/linux-x64": "^0.25.10"
   }
 }


### PR DESCRIPTION
## Summary
- add an explicit optional dependency on `@esbuild/linux-x64` so esbuild can locate the platform binary during Vite/Astro builds
- update the lockfile to include the optional dependency metadata

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e566d20b248332bdf16482212b30fb