### PR TITLE
Add section anchors and scroll offsets for Letter River case study

### DIFF
--- a/src/components/LetterRiverCaseStudy.jsx
+++ b/src/components/LetterRiverCaseStudy.jsx
@@ -344,7 +344,7 @@ export default function LetterRiverCaseStudy() {
         </section>
 
         {/* Challenge Section */}
-        <section className="py-20 md:py-28">
+        <section id="challenge" className="scroll-mt-28 py-20 md:py-28">
           <motion.div
             variants={fadeIn}
             initial="hidden"
@@ -397,7 +397,7 @@ export default function LetterRiverCaseStudy() {
         </section>
 
         {/* Process Section */}
-        <section className="py-20 md:py-28">
+        <section id="process" className="scroll-mt-28 py-20 md:py-28">
           <motion.div
             variants={fadeIn}
             initial="hidden"
@@ -435,7 +435,7 @@ export default function LetterRiverCaseStudy() {
         </section>
 
         {/* Development Journey Section */}
-        <section className="relative py-20 md:py-28">
+        <section id="journey" className="relative scroll-mt-28 py-20 md:py-28">
           <motion.h2
             variants={fadeIn}
             initial="hidden"
@@ -475,7 +475,7 @@ export default function LetterRiverCaseStudy() {
         </section>
 
         {/* Product Architecture */}
-        <section className="py-20 md:py-28">
+        <section id="architecture" className="scroll-mt-28 py-20 md:py-28">
           <motion.div
             variants={fadeIn}
             initial="hidden"
@@ -703,7 +703,7 @@ export default function LetterRiverCaseStudy() {
         </section>
 
         {/* Key Features & Technical Highlights */}
-        <section className="py-20 md:py-28">
+        <section id="features" className="scroll-mt-28 py-20 md:py-28">
           <motion.div
             variants={fadeIn}
             initial="hidden"
@@ -770,7 +770,7 @@ export default function LetterRiverCaseStudy() {
         </section>
 
         {/* Outcome + Next Validation */}
-        <section className="grid gap-8 py-20 md:py-28 lg:grid-cols-2 lg:items-start">
+        <section id="outcome" className="grid scroll-mt-28 gap-8 py-20 md:py-28 lg:grid-cols-2 lg:items-start">
           <motion.div
             variants={fadeIn}
             initial="hidden"

--- a/src/pages/letter-river.astro
+++ b/src/pages/letter-river.astro
@@ -2,7 +2,15 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import LetterRiverCaseStudy from '../components/LetterRiverCaseStudy.jsx';
 
-const navLinks = [{ href: '/', label: 'Home' }];
+const navLinks = [
+  { href: '/', label: 'Home' },
+  { href: '#challenge', label: 'Challenge' },
+  { href: '#process', label: 'Process' },
+  { href: '#journey', label: 'Journey' },
+  { href: '#architecture', label: 'Architecture' },
+  { href: '#features', label: 'Features' },
+  { href: '#outcome', label: 'Outcome' },
+];
 ---
 <BaseLayout title="Letter River Case Study | Jacob Meyerkopf" mainClass="p-0" navLinks={navLinks}>
   <LetterRiverCaseStudy client:load />


### PR DESCRIPTION
### Motivation
- Provide in-page navigation for the Letter River case study so nav links scroll to the correct sections with proper offset. 

### Description
- Add `id` attributes and `scroll-mt-28` to the case study `<section>` elements (`challenge`, `process`, `journey`, `architecture`, `features`, `outcome`) in `LetterRiverCaseStudy.jsx` to enable anchor targets with a comfortable scroll margin. 
- Update the `navLinks` array in `src/pages/letter-river.astro` to include anchor links for the new section ids. 

### Testing
- Started the local dev server with `npm run dev` and verified navigation anchors rendered without runtime errors. 
- Performed a production build with `npm run build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9a67565208332a77c48fb37098ad7)